### PR TITLE
Fixed typo

### DIFF
--- a/Copier/Copier.plugin.js
+++ b/Copier/Copier.plugin.js
@@ -609,7 +609,7 @@ const buildPlugin = ([Plugin, Api]) => {
                                     } 
                                 },
                                 {
-                                    label: "Messge Link",
+                                    label: "Message Link",
                                     id: "copy-message-link",
                                     action: () => {
                                         const channel = ChannelStore.getChannel(message.channel_id);


### PR DESCRIPTION
Just fixed a small typo.
Right click on message -> "Messge Link" -> changed to "Message Link"