### PR TITLE
fix: avatar position drifted

### DIFF
--- a/StatusEverywhere/components/avatar.scss
+++ b/StatusEverywhere/components/avatar.scss
@@ -3,6 +3,10 @@
     box-sizing: border-box;
 }
 
+.chatAvatar::before {
+    display: none;
+}
+
 .userPopout {
     border-radius: 50%;
     // background: var(--background-floating);

--- a/StatusEverywhere/package.json
+++ b/StatusEverywhere/package.json
@@ -1,7 +1,7 @@
 {
     "info": {
         "name": "StatusEverywhere",
-        "version": "2.3.2",
+        "version": "2.3.3",
         "authors": [
             {
                 "name": "Strencher",


### PR DESCRIPTION
Avatars in chat is being pushed by a meanless ::before pseudo-element provided by native Discord.
Don't know if this will be meaningful or not in future.

For now, by hiding the pseudo element to fix this problem.

Should keep tracking if this is going to be meaningful.


Resolves #156, resolves #157, resolves #158, resolves #162 and resolves #163.