### PR TITLE
Fixed Banner showing in My Account again

### DIFF
--- a/UserBackgrounds/banner.scss
+++ b/UserBackgrounds/banner.scss
@@ -35,6 +35,7 @@ $padding: 20px;
 /* UserBackground Plugin My Account fix by _david_ */
 :global(.accountProfileCard-lbN7n-) > .container {
     height: 100px;
+    display: flex;
 }
 :global(.accountProfileCard-lbN7n-) .badge + div,
 :global(.accountProfileCard-lbN7n-) .left + div {

--- a/UserBackgrounds/package.json
+++ b/UserBackgrounds/package.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"name": "UserBackgrounds",
-		"version": "1.6.3",
+		"version": "1.6.4",
 		"description": "A database of custom user requested backgrounds designed for BetterDiscord and Powercord.",
 		"authors": [
 			{


### PR DESCRIPTION
In the current version, the banner is not displayed in My Account. This is due to the `display: block`
![image](https://user-images.githubusercontent.com/50876016/170215935-6d18fa97-9849-4610-9aa2-7e745250a02a.png)

This changes the container back to `display: flex` for the My Account Panel
![image](https://user-images.githubusercontent.com/50876016/170216332-4a544712-7159-4ae4-9b94-3c60493414ea.png)
