### PR TITLE
Fixed issue in PlatformIndicators where client status never changes

### DIFF
--- a/PlatformIndicators/APlatformIndicators.plugin.js
+++ b/PlatformIndicators/APlatformIndicators.plugin.js
@@ -3,7 +3,7 @@
 * @displayName PlatformIndicators
 * @authorId 415849376598982656
 * @invite gvA2ree
-* @version 1.2.2
+* @version 1.2.3
 */
 /*@cc_on
 @if (@_jscript)
@@ -40,17 +40,17 @@ module.exports = (() => {
                     twitter_username: "Strencher3"
                 }
             ],
-            version: "1.2.2",
+            version: "1.2.3",
             description: "Adds indicators for every platform that the user is using. Source code available on the repo in the 'src' folder.",
             github: "https://github.com/Strencher/BetterDiscordStuff/blob/master/PlatformIndicators/APlatformIndicators.plugin.js",
             github_raw: "https://raw.githubusercontent.com/Strencher/BetterDiscordStuff/master/PlatformIndicators/APlatformIndicators.plugin.js"
         },
         changelog: [
             {
-                title: "v1.2.2",
+                title: "v1.2.3",
                 type: "fixed",
                 items: [
-                    "Fixed indicators not showing in the member list."
+                    "Fixed client's own status never changing."
                 ]
             },
         ],


### PR DESCRIPTION
In PlatformIndicators, ActionTypes was undefined and does not appear to be a member of DiscordConstants causing behavior such as the client status never updating until relaunched and the plugin failing to unload because it tries to reference ActionTypes when it calls Dispatcher.unsubscribe. This error is from the plugin being loaded:
```
Uncaught (in promise) TypeError: Cannot read property 'PRESENCE_UPDATE' of undefined
    at PlatformIndicators.onStart (betterdiscord://plugins/APlatformIndicators.plugin.js:343)
    at PlatformIndicators.start (betterdiscord://plugins/0PluginLibrary.plugin.js:3945)
    at Object.startPlugin (<anonymous>:4:307991)
    at Object.startAddon (<anonymous>:4:307784)
    at Object.loadAddon (<anonymous>:4:268485)
    at Object.loadAddon (<anonymous>:4:305881)
    at Object.loadAllAddons (<anonymous>:4:270609)
    at Object.initialize (<anonymous>:4:265058)
    at Object.initialize (<anonymous>:4:305091)
    at Object.startup (<anonymous>:4:367101)
```
In this pull request I just removed the status change listener made it get the status when the client's status is displayed.
I'm unsure if this is an issue with my client specifically and I'm sorry if it is.
